### PR TITLE
[Temporary Fix] Add bytes to hex decoder

### DIFF
--- a/ethindex/pgimport.py
+++ b/ethindex/pgimport.py
@@ -50,7 +50,15 @@ def hexlify(d):
     return "0x" + binascii.hexlify(d).decode()
 
 
+def bytesArgsToHex(args):
+    for key in args:
+        if type(args[key]) is bytes:
+            args[key] = hexlify(args[key])
+    return args
+
+
 def insert_event(cur, event: logdecode.Event) -> None:
+    event.args = bytesArgsToHex(event.args)
     cur.execute(
         """INSERT INTO events (transactionHash,
                                        blockNumber,


### PR DESCRIPTION
When a `bytes` arg was in `event.args` the indexer could not insert the event. Instead the error
```
TypeError: Object of type 'bytes' is not JSON serializable
```
was thrown.