### PR TITLE
make travis use a non-shallow git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+git:
+  depth: false
 install:
 # install from requirements first, because that installs the non-binary psycopg2
   - pip install -c constraints.txt -r requirements.txt


### PR DESCRIPTION
since we use setuptools_scm, we also need a non-shallow git clone of our
repository. Otherwise the version will be wrong.