### PR TITLE
show total number of blocks in log message

### DIFF
--- a/ethindex/pgimport.py
+++ b/ethindex/pgimport.py
@@ -162,9 +162,10 @@ class Synchronizer:
         events = get_events(self.web3, self.topic_index, fromBlock, toBlock)
         blocknumbers = event_blocknumbers(events)
         logger.info(
-            "got %s events in %s blocks (%s -> %s)",
+            "got %s events in %s out of %s blocks (%s -> %s)",
             len(events),
             len(blocknumbers),
+            toBlock - fromBlock + 1,
             fromBlock,
             toBlock,
         )


### PR DESCRIPTION
The log message now looks like the following, which is bit less confusing:

,----
| INFO:ethindex.pgimport:got 0 events in 0 out of 6 blocks (1449524 -> 1449529)
`----