### PR TITLE
use ubuntu 18.04 as a base docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+build
+dist
+*.egg-info
+*.egg/
+*.eggs/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.swp
+*~
+
+.dockerignore
+.tox
+.coverage
+html/*
+__pycache__
+
+# Compiled Documentation
+docs/_build
+
+.mypy_cache/
+.idea
+venv/
+local/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ psycopg2>=2.7,<2.8 --no-binary psycopg2
 web3
 click
 attrs
-
 # --- development dependencies, i.e. dependencies not needed for running ethindex
 black
 coverage
@@ -10,4 +9,4 @@ flake8
 flake8-invalid-escape-sequences
 flake8-string-format
 mypy
-pytest==3.2.5
+pytest


### PR DESCRIPTION
This gives us a much smaller image. du reports around 160M for the root
filesystem now (vs 978M for the old image).

We now need to install the development environment in the builder image.

This also has the added benefit of using kind of a 'standard image', see
https://blog.ubuntu.com/2018/07/09/minimal-ubuntu-released