### PR TITLE
handle chain reorgs by refetching events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+`0.2.0`_ (not release yet)
+--------------------------
+* ethindex handles chain reorgs
+* the database schema has been changed. Please rebuild your database
+
 `0.1.1`_ (2018-08-21)
 -----------------------
 * eth-index has been released on PyPI
@@ -9,3 +14,4 @@ Change Log
 
 
 .. _0.1.1: https://github.com/trustlines-network/py-eth-index/compare/0.1.0...0.1.1
+.. _0.2.0: https://github.com/trustlines-network/py-eth-index/compare/0.1.1...0.2.0

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,6 @@ Status and Limitations
 ----------------------
 
 - ethindex is alpha software.
-- ethindex currently does not handle chain reorgs
 - there currently is no way to add more contracts to index
 
 Change log

--- a/ethindex/pgimport.py
+++ b/ethindex/pgimport.py
@@ -115,12 +115,11 @@ def insert_sync_entry(conn, syncid, addresses, start_block=-1):
         cur.execute(
             """INSERT INTO SYNC (syncid,
                                  last_block_number,
-                                 last_block_hash,
                                  addresses,
                                  last_confirmed_block_number,
                                  latest_block_hash)
-               VALUES (%s, %s, %s, %s, %s, %s)""",
-            (syncid, start_block, "", list(addresses), start_block, ""),
+               VALUES (%s, %s, %s, %s, %s)""",
+            (syncid, start_block, list(addresses), start_block, ""),
         )
 
 
@@ -307,7 +306,6 @@ def do_createtables(conn):
                   CREATE TABLE sync (
                     syncid TEXT NOT NULL PRIMARY KEY,
                     last_block_number INTEGER NOT NULL,
-                    last_block_hash TEXT NOT NULL,
                     addresses TEXT[] NOT NULL,
                     last_confirmed_block_number INTEGER NOT NULL,
                     latest_block_hash TEXT NOT NULL

--- a/ethindex/pgimport.py
+++ b/ethindex/pgimport.py
@@ -202,7 +202,7 @@ class Synchronizer:
             )
         self.conn.commit()
 
-    def sync_some_blocks(self, waittime):
+    def sync_some_blocks(self, waittime, stop_when_synced=False):
         while 1:
             latest_block = self.web3.eth.getBlock("latest")
             latest_block_hash = hexlify(latest_block["hash"])
@@ -225,8 +225,13 @@ class Synchronizer:
                     fromBlock, toBlock, last_confirmed_block_number, latest_block_hash
                 )
             else:
+                if stop_when_synced:
+                    return
                 logger.info("already synced up to latest block %s", toBlock)
                 time.sleep(waittime)
+
+    def sync_until_current(self):
+        self.sync_some_blocks(1000, stop_when_synced=True)
 
 
 @click.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 import attr
 from typing import List, Any
 from ethindex import logdecode
+import eth_utils
 
 
 @pytest.fixture(scope="session")
@@ -81,10 +82,16 @@ class TestEnv:
     contracts: List[Any]
     abi: Any
     topic_index: logdecode.TopicIndex
+    ethereum_tester: eth_tester.EthereumTester
 
 
 @pytest.fixture
-def testenv(ethereum_tester, compiled_contracts, tmpdir, contracts_json_path):
+def testenv(
+    ethereum_tester: eth_tester.EthereumTester,
+    compiled_contracts,
+    tmpdir,
+    contracts_json_path,
+):
     web3 = Web3(EthereumTesterProvider(ethereum_tester))
     web3.eth.defaultAccount = web3.eth.accounts[0]
 
@@ -113,6 +120,7 @@ def testenv(ethereum_tester, compiled_contracts, tmpdir, contracts_json_path):
         logdecode.TopicIndex(
             {contract_address: abi for contract_address in contract_addresses}
         ),
+        ethereum_tester,
     )
     ethereum_tester.revert_to_snapshot(snapshot)
 
@@ -120,3 +128,27 @@ def testenv(ethereum_tester, compiled_contracts, tmpdir, contracts_json_path):
 @pytest.fixture
 def web3_eth_tester(testenv):
     return testenv.web3
+
+
+def make_address(i: int):
+    return eth_utils.to_checksum_address("0x{:040X}".format(i))
+
+
+class EventEmitter:
+    """this class is used to emit events into the blockchain"""
+
+    def __init__(self, testenv):
+        self.testenv = testenv
+        self.value = 0
+
+    def add_some_tranfer_events(self):
+        for i, contract in enumerate(self.testenv.contracts):
+            contract.functions.makeTransfer(
+                make_address(i), make_address(i + 1), self.value
+            ).transact()
+            self.value += 1
+
+
+@pytest.fixture
+def event_emitter(testenv):
+    return EventEmitter(testenv)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 import attr
 from typing import List, Any
-from ethindex import logdecode
+from ethindex import logdecode, pgimport
 import eth_utils
 
 
@@ -152,3 +152,16 @@ class EventEmitter:
 @pytest.fixture
 def event_emitter(testenv):
     return EventEmitter(testenv)
+
+
+@pytest.fixture
+def synchronizer(testenv, conn):
+    pgimport.do_createtables(conn)
+    pgimport.do_importabi(
+        conn, testenv.addresses_json_path, testenv.contracts_json_path
+    )
+    pgimport.ensure_default_entry(conn)
+    synchronizer = pgimport.Synchronizer(
+        conn, testenv.web3, "default", required_confirmations=10
+    )
+    return synchronizer

--- a/tests/test_chain_reorg.py
+++ b/tests/test_chain_reorg.py
@@ -1,0 +1,29 @@
+"""test that chain reorgs are handled"""
+
+
+def fetch_events(conn):
+    with conn.cursor() as cur:
+        cur.execute("select * from events order by blocknumber")
+        rows = cur.fetchall()
+        print(rows)
+        return [event["args"]["_value"] for event in rows]
+
+
+def test_reorg(testenv, event_emitter, conn, synchronizer):
+    # event_emitter.add_some_tranfer_events adds 3 events increases the value
+    # added by one for each event
+
+    event_emitter.add_some_tranfer_events()  # add events with values 0, 1, 2
+    snapshot = testenv.ethereum_tester.take_snapshot()
+    event_emitter.add_some_tranfer_events()  # add events with values 3, 4, 5
+    synchronizer.sync_until_current()
+    values_before = fetch_events(conn)
+    assert values_before == [0, 1, 2, 3, 4, 5]
+
+    # now reorg the chain
+    testenv.ethereum_tester.revert_to_snapshot(snapshot)
+    event_emitter.add_some_tranfer_events()  # add events with values 6, 7, 8
+    event_emitter.add_some_tranfer_events()  # add events with values 9, 10, 11
+    synchronizer.sync_until_current()
+    values_after = fetch_events(conn)
+    assert values_after == [0, 1, 2, 6, 7, 8, 9, 10, 11]


### PR DESCRIPTION
we consider events/blocks from the chain final if they had
Synchronizer.required_confirmations confirmations. When the chain moves forward,
we fetch events for all blocks that were not considered final till the end of
the chain.

If blocks come in one by one, this means we're fetching events for each block
required_confirmations times. This may become something we have to optimize.

In that case take a look at the other solution I proposed in
https://github.com/trustlines-network/py-eth-index/pull/28 (exclude the last
commit), which would only fetch events for each block twice at most. The
disadvantage being that we may have some inconsistencies in the last blocks and
the chain reorg detection would still have to implemented.

Anyway, this solution here is a bit rude, but it is much simpler.

see issue https://github.com/trustlines-network/py-eth-index/issues/4 and
https://github.com/trustlines-network/py-eth-index/pull/28 for my previous
attempt.