### PR TITLE
add failing test case for sync_until_current

### DIFF
--- a/ethindex/pgimport.py
+++ b/ethindex/pgimport.py
@@ -218,8 +218,8 @@ class Synchronizer:
                 min(toBlock, latest_block_number - self.required_confirmations), -1
             )
             if fromBlock <= toBlock and (
-                toBlock < latest_block_number
-                or latest_block_hash != self.latest_block_hash
+                self.last_block_number != latest_block_number
+                or self.latest_block_hash != latest_block_hash
             ):
                 self._sync_blocks(
                     fromBlock, toBlock, last_confirmed_block_number, latest_block_hash


### PR DESCRIPTION
we wrongly detect we're already synced when in fact we are not.