### PR TITLE
Fix install on python 3.8.5

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,7 @@ cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
 coverage==4.5.4
-cytoolz==0.10.0
+cytoolz==0.10.1
 entrypoints==0.3
 eth-abi==2.0.0
 eth-account==0.4.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ flake8-string-format==0.2.3
 hexbytes==0.2.0
 identify==1.4.5
 idna==2.8
-importlib-metadata==0.19
+importlib-metadata==1.7.0
 ipfshttpclient==0.4.12
 jsonschema==2.6.0
 lru-dict==1.1.6
@@ -64,12 +64,12 @@ rlp==1.1.0
 scramp==1.1.0
 semantic-version==2.6.0
 setuptools==41.0.1
-six==1.12.0
+six==1.14.0
 testing.common.database==2.0.3
 testing.postgresql==1.3.0
 toml==0.10.0
 toolz==0.10.0
-tox==3.13.2
+tox==3.19.0
 trie==1.4.0
 typed-ast==1.4.0
 typing-extensions==3.7.4


### PR DESCRIPTION
Cytools was failing to compile on mac with python 3.8.5. The problem appears to have been fixed in 0.10.1 with this PR: https://github.com/pytoolz/cytoolz/pull/137