### PR TITLE
Write in table `graphfeed` information to sync trustline graph

### DIFF
--- a/src/ethindex/logdecode.py
+++ b/src/ethindex/logdecode.py
@@ -111,6 +111,14 @@ class Event:
         return self.log["logIndex"]
 
 
+@attr.s(auto_attribs=True)
+class GraphUpdate:
+    name: str
+    args: Dict
+    address: str
+    timestamp: Optional[int]
+
+
 class TopicIndex:
     def __init__(self, address2abi):
         """build a TopicIndex from an contract address to ABI dict"""


### PR DESCRIPTION
The information written is the trustlines update and balance update
information taken from events as they appear in the chain.
If an event is no longer in the chain due to a reorg, the information
of the last state of the impacted trustline is written instead.