### PR TITLE
No longer raise RunetimeError when getting events with unknown abi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ==========
 Change Log
 ==========
+`unreleased`_
+---------------------
+- Changed: no longer raiser RuntimeError when receiving an event of unknown abi but log a warning.
+  This is useful for proxied contracts that may emit events related to the proxy administration.
+
 `0.3.4`_ (2020-12-18)
 ---------------------
 - Use events from database to figure out sent events to relay instead of memory.
@@ -51,3 +56,4 @@ Change Log
 .. _0.3.2: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.1...0.3.2
 .. _0.3.3: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.2...0.3.3
 .. _0.3.4: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.3...0.3.4
+.. _unreleased: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.4...master

--- a/src/ethindex/pgimport.py
+++ b/src/ethindex/pgimport.py
@@ -49,10 +49,8 @@ def get_logs(web3, addresses, fromBlock, toBlock):
 
 
 def get_events(web3, topic_index, fromBlock, toBlock) -> Iterable[logdecode.Event]:
-    return [
-        topic_index.decode_log(x)
-        for x in get_logs(web3, topic_index.addresses, fromBlock, toBlock)
-    ]
+    logs = get_logs(web3, topic_index.addresses, fromBlock, toBlock)
+    return topic_index.decode_logs(logs)
 
 
 def hexlify(d):

--- a/tests/build/contracts.json
+++ b/tests/build/contracts.json
@@ -2,30 +2,7 @@
     "CurrencyNetwork": {
         "abi": [
             {
-                "constant": false,
-                "inputs": [
-                    {
-                        "name": "_from",
-                        "type": "address"
-                    },
-                    {
-                        "name": "_to",
-                        "type": "address"
-                    },
-                    {
-                        "name": "_value",
-                        "type": "uint256"
-                    }
-                ],
-                "name": "makeTransfer",
-                "outputs": [],
-                "payable": false,
-                "stateMutability": "nonpayable",
-                "type": "function"
-            },
-            {
                 "inputs": [],
-                "payable": false,
                 "stateMutability": "nonpayable",
                 "type": "constructor"
             },
@@ -34,62 +11,73 @@
                 "inputs": [
                     {
                         "indexed": true,
+                        "internalType": "address",
                         "name": "_from",
                         "type": "address"
                     },
                     {
                         "indexed": true,
+                        "internalType": "address",
                         "name": "_to",
                         "type": "address"
                     },
                     {
                         "indexed": false,
+                        "internalType": "uint256",
                         "name": "_value",
                         "type": "uint256"
                     }
                 ],
                 "name": "Transfer",
                 "type": "event"
+            },
+            {
+                "inputs": [],
+                "name": "emitUnknownAbiEvent",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "internalType": "address",
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "makeTransfer",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
             }
         ],
-        "bytecode": "0x608060405234801561001057600080fd5b50610149806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a6e4915414610046575b600080fd5b34801561005257600080fd5b506100b1600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803590602001909291905050506100b3565b005b8173ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040518082815260200191505060405180910390a35050505600a165627a7a72305820136dff3039c4b0f03151bf1868a30b9cbdd2e368936019903155461c7c3bab560029",
-        "bytecode_runtime": "0x608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a6e4915414610046575b600080fd5b34801561005257600080fd5b506100b1600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803590602001909291905050506100b3565b005b8173ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040518082815260200191505060405180910390a35050505600a165627a7a72305820136dff3039c4b0f03151bf1868a30b9cbdd2e368936019903155461c7c3bab560029",
-        "direct_dependencies": [],
-        "full_dependencies": [],
-        "linkrefs": [],
-        "linkrefs_runtime": [],
+        "devdoc": {
+            "kind": "dev",
+            "methods": {},
+            "version": 1
+        },
+        "bytecode": "0x608060405234801561001057600080fd5b50610178806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063243f91301461003b578063a6e4915414610045575b600080fd5b610043610058565b005b6100436100533660046100fe565b610092565b7f9d2e69f9500d7a074ad90c8754ebc9ada42f70a2ce0d3cfb9c6cfb72933ed3fa602a6040516100889190610139565b60405180910390a1565b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040516100d59190610139565b60405180910390a3505050565b80356001600160a01b03811681146100f957600080fd5b919050565b600080600060608486031215610112578283fd5b61011b846100e2565b9250610129602085016100e2565b9150604084013590509250925092565b9081526020019056fea26469706673582212209d4a2a4d9826b3b917bcb0f0cd8829196ba4ab98456ac5141d542e0a3c60abb064736f6c63430008000033",
+        "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100365760003560e01c8063243f91301461003b578063a6e4915414610045575b600080fd5b610043610058565b005b6100436100533660046100fe565b610092565b7f9d2e69f9500d7a074ad90c8754ebc9ada42f70a2ce0d3cfb9c6cfb72933ed3fa602a6040516100889190610139565b60405180910390a1565b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040516100d59190610139565b60405180910390a3505050565b80356001600160a01b03811681146100f957600080fd5b919050565b600080600060608486031215610112578283fd5b61011b846100e2565b9250610129602085016100e2565b9150604084013590509250925092565b9081526020019056fea26469706673582212209d4a2a4d9826b3b917bcb0f0cd8829196ba4ab98456ac5141d542e0a3c60abb064736f6c63430008000033",
         "metadata": {
             "compiler": {
-                "version": "0.4.23+commit.124ca40d"
+                "version": "0.8.0+commit.c7dfd78e"
             },
             "language": "Solidity",
             "output": {
                 "abi": [
                     {
-                        "constant": false,
-                        "inputs": [
-                            {
-                                "name": "_from",
-                                "type": "address"
-                            },
-                            {
-                                "name": "_to",
-                                "type": "address"
-                            },
-                            {
-                                "name": "_value",
-                                "type": "uint256"
-                            }
-                        ],
-                        "name": "makeTransfer",
-                        "outputs": [],
-                        "payable": false,
-                        "stateMutability": "nonpayable",
-                        "type": "function"
-                    },
-                    {
                         "inputs": [],
-                        "payable": false,
                         "stateMutability": "nonpayable",
                         "type": "constructor"
                     },
@@ -98,55 +86,111 @@
                         "inputs": [
                             {
                                 "indexed": true,
+                                "internalType": "address",
                                 "name": "_from",
                                 "type": "address"
                             },
                             {
                                 "indexed": true,
+                                "internalType": "address",
                                 "name": "_to",
                                 "type": "address"
                             },
                             {
                                 "indexed": false,
+                                "internalType": "uint256",
                                 "name": "_value",
                                 "type": "uint256"
                             }
                         ],
                         "name": "Transfer",
                         "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "internalType": "int256",
+                                "name": "_value",
+                                "type": "int256"
+                            }
+                        ],
+                        "name": "UnknownAbiEvent",
+                        "type": "event"
+                    },
+                    {
+                        "inputs": [],
+                        "name": "emitUnknownAbiEvent",
+                        "outputs": [],
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            {
+                                "internalType": "address",
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "address",
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "internalType": "uint256",
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "makeTransfer",
+                        "outputs": [],
+                        "stateMutability": "nonpayable",
+                        "type": "function"
                     }
                 ],
                 "devdoc": {
-                    "methods": {}
+                    "kind": "dev",
+                    "methods": {},
+                    "version": 1
                 },
                 "userdoc": {
-                    "methods": {}
+                    "kind": "user",
+                    "methods": {},
+                    "version": 1
                 }
             },
             "settings": {
                 "compilationTarget": {
                     "contracts/CurrencyNetwork.sol": "CurrencyNetwork"
                 },
-                "evmVersion": "byzantium",
+                "evmVersion": "petersburg",
                 "libraries": {},
+                "metadata": {
+                    "bytecodeHash": "ipfs"
+                },
                 "optimizer": {
-                    "enabled": false,
-                    "runs": 200
+                    "enabled": true,
+                    "runs": 500
                 },
                 "remappings": []
             },
             "sources": {
                 "contracts/CurrencyNetwork.sol": {
-                    "keccak256": "0xf0ad1ac30d23d48fa5383f2528d8ed0519dd26ddde4f72d6d97ac8221a9a8cc4",
+                    "keccak256": "0x063e66078738223b45f9b498876f8a624c9189fe01ddd39029c5604343dcd69f",
                     "urls": [
-                        "bzzr://5d5873835f23d1af58be9d1b6a2ddb2beeecc20e4cf0ee196caef51ddb72fd5c"
+                        "bzz-raw://f04db38dbee34289ea5bcb16a053cd8f5a0bd383f1ad00ae1f819a4fad0a9a92",
+                        "dweb:/ipfs/QmfWvzNiwD9c2XgAe3CQrsCBJPuJ1TkBeQdFvwDNRKsowQ"
                     ]
                 }
             },
             "version": 1
         },
-        "name": "CurrencyNetwork",
-        "ordered_full_dependencies": [],
-        "source_path": "contracts/CurrencyNetwork.sol"
+        "userdoc": {
+            "kind": "user",
+            "methods": {},
+            "version": 1
+        }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,10 @@ class EventEmitter:
             ).transact()
             self.value += 1
 
+    def add_unknown_abi_events(self):
+        for contract in self.testenv.contracts:
+            contract.functions.emitUnknownAbiEvent().transact()
+
 
 @pytest.fixture
 def event_emitter(testenv):

--- a/tests/contracts/CurrencyNetwork.sol
+++ b/tests/contracts/CurrencyNetwork.sol
@@ -1,15 +1,23 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.8.0;
 
 // This class has to be called CurrencyNetwork, because we need to be compatible with
 // logdecode.build_address_to_abi_dict
+//
+// We build the contracts.json manually and remove the abi for the UnknownAbiEvent to test
+// having an event without its abi
 
 contract CurrencyNetwork {
   event Transfer(address indexed _from, address indexed _to, uint _value);
+  event UnknownAbiEvent(int _value);
 
-  function CurrencyNetwork() public {
+  constructor() {
   }
 
   function makeTransfer(address _from, address _to, uint _value) public {
     emit Transfer(_from, _to, _value);
+  }
+
+  function emitUnknownAbiEvent() public {
+    emit UnknownAbiEvent(42);
   }
 }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -44,3 +44,20 @@ def test_topic_index_from_db(testenv, event_emitter, conn):
     events3 = pgimport.get_events(testenv.web3, topic_index3, 0, "latest")
     assert events1 == events2
     assert events1 == events3
+
+
+def test_should_not_crash_on_unknown_event(testenv, event_emitter, conn):
+    """Test that the indexer will not emit an error when an unknown event is emitted from an indexed address"""
+    for abi_element in testenv.abi:
+        if abi_element["type"] == "event":
+            assert (
+                abi_element["name"] != "UnknownAbiEvent"
+            ), "Remove the UnknownAbiEvent from the abi to run this test properly."
+
+    event_emitter.add_unknown_abi_events()
+    pgimport.do_createtables(conn)
+    pgimport.do_importabi(
+        conn, testenv.addresses_json_path, testenv.contracts_json_path
+    )
+
+    pgimport.get_events(testenv.web3, testenv.topic_index, 0, "latest")


### PR DESCRIPTION
This is useful for proxied contracts that may emit events related
to the proxy administration and not to the proxied contract (e.g.
CurrencyNetwork) that the indexer should not care about.