### PR TITLE
Warn instead of crashing when attempting to create tables that exist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Change Log
 ---------------------
 - Changed: no longer raiser RuntimeError when receiving an event of unknown abi but log a warning.
   This is useful for proxied contracts that may emit events related to the proxy administration.
+- Changed: createtable will warn if table already exists instead of crashing.
+  This allow to upgrade ethindex from versions where the graphfeed table did not exist to ones where it does.
 
 `0.3.4`_ (2020-12-18)
 ---------------------


### PR DESCRIPTION
This just checks for table name. I'd like to find a way to also check if the existing table has the correct schema.