### PR TITLE
Load abi from tlbin by default in `importabi`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Change Log
 ==========
 `unreleased`_
 ---------------------
+- By default, direclty load abi from `tlbin` package on command `ethindex importabi`
+  you can still provide option `--contracts <path>` to use custom abi
 
 `0.4.0`_ (2021-03-04)
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Change Log
 ==========
 `unreleased`_
 ---------------------
+
+`0.4.1`_ (2021-04-27)
+---------------------
 - By default, direclty load abi from `tlbin` package on command `ethindex importabi`
   you can still provide option `--contracts <path>` to use custom abi
 - Command `ethindex importabi` now erases the old abi if an abi for an address was already imported.
@@ -78,4 +81,5 @@ Change Log
 .. _0.3.4: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.3...0.3.4
 .. _0.3.5: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.4...0.3.5
 .. _0.4.0: https://github.com/trustlines-protocol/py-eth-index/compare/0.3.5...0.4.0
-.. _unreleased: https://github.com/trustlines-protocol/py-eth-index/compare/0.4.0...master
+.. _0.4.1: https://github.com/trustlines-protocol/py-eth-index/compare/0.4.0...0.4.1
+.. _unreleased: https://github.com/trustlines-protocol/py-eth-index/compare/0.4.1...master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Change Log
 ---------------------
 - By default, direclty load abi from `tlbin` package on command `ethindex importabi`
   you can still provide option `--contracts <path>` to use custom abi
+- Command `ethindex importabi` now erases the old abi if an abi for an address was already imported.
+  This allows to rerun the command to update abi without having to drop the table.
 
 `0.4.0`_ (2021-03-04)
 ---------------------

--- a/constraints.txt
+++ b/constraints.txt
@@ -70,6 +70,7 @@ toml==0.10.2
 toolz==0.10.0
 tox==3.23.0
 trie==1.4.0
+trustlines-contracts-bin==2.0.0
 typed-ast==1.4.2
 typing-extensions==3.7.4
 urllib3==1.25.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     psycopg2>=2.7
     click
     attrs
+    tlbin>=1.4.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     psycopg2>=2.7
     click
     attrs
-    tlbin>=1.4.0
+    trustlines-contracts-bin>=2.0.0
 
 [options.entry_points]
 console_scripts =

--- a/src/ethindex/logdecode.py
+++ b/src/ethindex/logdecode.py
@@ -43,7 +43,7 @@ def build_address_to_abi_dict(
         ]["abi"]
 
     for network in addresses_json["networks"]:
-        add_abi(network, "CurrencyNetworkOwnable")
+        add_abi(network, "MergedCurrencyNetworksAbi")
 
     if "unwEth" in addresses_json:
         add_abi(addresses_json["unwEth"], "UnwEth")

--- a/src/ethindex/pgimport.py
+++ b/src/ethindex/pgimport.py
@@ -600,7 +600,8 @@ def do_importabi(conn, addresses, contracts=None):
                 cur.execute(
                     """INSERT INTO abis (contract_address, abi)
                        VALUES (%s, %s)
-                       ON CONFLICT(contract_address) DO NOTHING""",
+                       ON CONFLICT(contract_address) DO UPDATE SET abi = EXCLUDED.abi
+                    """,
                     (contract_address, json.dumps(abi)),
                 )
 

--- a/tests/build/contracts.json
+++ b/tests/build/contracts.json
@@ -1,5 +1,5 @@
 {
-    "CurrencyNetworkOwnable": {
+    "MergedCurrencyNetworksAbi": {
         "abi": [
             {
                 "inputs": [],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def testenv(
     web3 = Web3(EthereumTesterProvider(ethereum_tester))
     web3.eth.defaultAccount = web3.eth.accounts[0]
 
-    contract_interface = compiled_contracts["CurrencyNetworkOwnable"]
+    contract_interface = compiled_contracts["MergedCurrencyNetworksAbi"]
     contract_addresses = [deploy_contract(web3, contract_interface) for i in range(3)]
     currency_networks = [
         web3.eth.contract(address=contract_address, abi=contract_interface["abi"])

--- a/tests/contracts/MergedCurrencyNetworksAbi.sol
+++ b/tests/contracts/MergedCurrencyNetworksAbi.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.8.0;
 
-// This class has to be called CurrencyNetwork, because we need to be compatible with
+// This class has to be called MergedCurrencyNetworksAbi, because we need to be compatible with
 // logdecode.build_address_to_abi_dict
 //
 // We build the contracts.json manually and remove the abi for the UnknownAbiEvent to test
 // having an event without its abi
 
-contract CurrencyNetworkOwnable {
+contract MergedCurrencyNetworksAbi {
   event Transfer(address indexed _from, address indexed _to, uint _value);
   event UnknownAbiEvent(int _value);
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,14 +43,7 @@ def test_importabi(conn, testenv):
     err = subprocess.call(["ethindex", "createtables"])
     assert err == 0
     err = subprocess.call(
-        [
-            "ethindex",
-            "importabi",
-            "--addresses",
-            testenv.addresses_json_path,
-            "--contracts",
-            testenv.contracts_json_path,
-        ]
+        ["ethindex", "importabi", "--addresses", testenv.addresses_json_path]
     )
     assert err == 0
     with conn.cursor() as cur:


### PR DESCRIPTION
Use the tlbin package to load abi when no contracts.json is provided
in command `ethindex importabi`. This avoids having to bother
finding out the abi.

Requires: https://github.com/trustlines-protocol/contracts/pull/394